### PR TITLE
Premium UI/UX redesign + functional kanban board

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ sw.\*
 \*.swp
 
 .history/
+.gstack/

--- a/assets/styles/theme.scss
+++ b/assets/styles/theme.scss
@@ -1,0 +1,455 @@
+/* =========================================================================
+   Tasks — Design System
+   Modern minimal · indigo accent · light + dark
+   ========================================================================= */
+
+:root {
+  /* Canvas + surfaces */
+  --bg: #f6f7f9;
+  --bg-grad-1: #eef0f5;
+  --bg-grad-2: #f7f8fa;
+  --surface: #ffffff;
+  --surface-2: #f3f4f7;
+  --surface-3: #eceef2;
+  --surface-hover: #f8f9fb;
+
+  /* Lines */
+  --border: rgba(15, 23, 42, 0.08);
+  --border-strong: rgba(15, 23, 42, 0.14);
+
+  /* Text */
+  --text: #0f172a;
+  --text-secondary: #475569;
+  --text-muted: #94a3b8;
+  --text-onaccent: #ffffff;
+
+  /* Accent */
+  --accent: #6366f1;
+  --accent-hover: #4f46e5;
+  --accent-soft: rgba(99, 102, 241, 0.12);
+  --accent-ring: rgba(99, 102, 241, 0.35);
+  --accent-grad: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+
+  /* Column / status accents */
+  --c-todo: #6366f1;
+  --c-todo-soft: rgba(99, 102, 241, 0.12);
+  --c-progress: #f59e0b;
+  --c-progress-soft: rgba(245, 158, 11, 0.14);
+  --c-done: #10b981;
+  --c-done-soft: rgba(16, 185, 129, 0.14);
+
+  /* Priorities */
+  --p-low: #10b981;
+  --p-medium: #f59e0b;
+  --p-high: #ef4444;
+
+  /* Shadows */
+  --shadow-xs: 0 1px 2px rgba(15, 23, 42, 0.04);
+  --shadow-sm: 0 1px 3px rgba(15, 23, 42, 0.06), 0 1px 2px rgba(15, 23, 42, 0.04);
+  --shadow-md: 0 4px 12px rgba(15, 23, 42, 0.07), 0 2px 4px rgba(15, 23, 42, 0.04);
+  --shadow-lg: 0 12px 32px rgba(15, 23, 42, 0.1), 0 4px 8px rgba(15, 23, 42, 0.05);
+  --shadow-xl: 0 24px 48px rgba(15, 23, 42, 0.14);
+  --shadow-accent: 0 8px 24px rgba(99, 102, 241, 0.32);
+
+  /* Radii */
+  --r-sm: 8px;
+  --r-md: 12px;
+  --r-lg: 16px;
+  --r-xl: 22px;
+  --r-full: 9999px;
+
+  --ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --dur: 220ms;
+
+  /* Type */
+  --font-sans: 'Satoshi', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-display: 'Clash Display', var(--font-sans);
+
+  /* Crafted-surface tokens */
+  --grid-dot: rgba(15, 23, 42, 0.05);
+  --inset-hi: rgba(255, 255, 255, 0.65);
+  --hairline: rgba(15, 23, 42, 0.06);
+  --grain-opacity: 0.028;
+}
+
+.dark {
+  --bg: #0a0b10;
+  --bg-grad-1: #11131b;
+  --bg-grad-2: #0a0b10;
+  --surface: #14161f;
+  --surface-2: #1a1d28;
+  --surface-3: #222634;
+  --surface-hover: #1c1f2b;
+
+  --border: rgba(255, 255, 255, 0.07);
+  --border-strong: rgba(255, 255, 255, 0.13);
+
+  --text: #f1f5f9;
+  --text-secondary: #aab4c5;
+  --text-muted: #6b7689;
+  --text-onaccent: #ffffff;
+
+  --accent: #818cf8;
+  --accent-hover: #a5b4fc;
+  --accent-soft: rgba(129, 140, 248, 0.16);
+  --accent-ring: rgba(129, 140, 248, 0.4);
+  --accent-grad: linear-gradient(135deg, #818cf8 0%, #a78bfa 100%);
+
+  --c-todo: #818cf8;
+  --c-todo-soft: rgba(129, 140, 248, 0.16);
+  --c-progress: #fbbf24;
+  --c-progress-soft: rgba(251, 191, 36, 0.16);
+  --c-done: #34d399;
+  --c-done-soft: rgba(52, 211, 153, 0.16);
+
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.5);
+  --shadow-md: 0 6px 16px rgba(0, 0, 0, 0.45);
+  --shadow-lg: 0 16px 40px rgba(0, 0, 0, 0.55);
+  --shadow-xl: 0 28px 60px rgba(0, 0, 0, 0.65);
+  --shadow-accent: 0 8px 28px rgba(99, 102, 241, 0.45);
+
+  --grid-dot: rgba(255, 255, 255, 0.05);
+  --inset-hi: rgba(255, 255, 255, 0.06);
+  --hairline: rgba(255, 255, 255, 0.08);
+  --grain-opacity: 0.04;
+}
+
+/* ----------------------------------------------------------------------- */
+/* Base                                                                     */
+/* ----------------------------------------------------------------------- */
+* {
+  box-sizing: border-box;
+}
+
+html {
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  line-height: 1.55;
+}
+
+body {
+  margin: 0;
+  color: var(--text);
+  background-color: var(--bg);
+  background-image: radial-gradient(
+      1100px 560px at 88% -8%,
+      var(--bg-grad-1),
+      transparent 58%
+    ),
+    radial-gradient(820px 460px at -12% 112%, var(--bg-grad-1), transparent 52%);
+  background-attachment: fixed;
+  transition: background-color var(--dur) var(--ease), color var(--dur) var(--ease);
+  min-height: 100vh;
+}
+
+/* Film grain — the quiet "expensive" layer. Sits above everything,
+   ignores pointer events, near-invisible but felt. */
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  pointer-events: none;
+  opacity: var(--grain-opacity);
+  mix-blend-mode: overlay;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+h1, h2, h3, h4, h5, h6 {
+  letter-spacing: -0.02em;
+  color: var(--text);
+  margin: 0;
+}
+
+.font-display {
+  font-family: var(--font-display);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+::selection {
+  background: var(--accent-soft);
+  color: var(--text);
+}
+
+/* Scrollbars */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-strong) transparent;
+}
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+*::-webkit-scrollbar-thumb {
+  background: var(--border-strong);
+  border-radius: var(--r-full);
+  border: 3px solid transparent;
+  background-clip: padding-box;
+}
+*::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted);
+  background-clip: padding-box;
+}
+
+/* Focus ring */
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* ----------------------------------------------------------------------- */
+/* Reusable atoms                                                           */
+/* ----------------------------------------------------------------------- */
+.surface-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  box-shadow: var(--shadow-sm), inset 0 1px 0 var(--inset-hi);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  line-height: 1;
+  padding: 0 16px;
+  height: 40px;
+  border-radius: var(--r-md);
+  border: 1px solid transparent;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color var(--dur) var(--ease),
+    border-color var(--dur) var(--ease), color var(--dur) var(--ease),
+    box-shadow var(--dur) var(--ease), transform 120ms var(--ease);
+  user-select: none;
+}
+.btn:active {
+  transform: translateY(1px);
+}
+.btn-primary {
+  position: relative;
+  overflow: hidden;
+  background: var(--accent-grad);
+  color: var(--text-onaccent);
+  box-shadow: var(--shadow-accent), inset 0 1px 0 rgba(255, 255, 255, 0.25);
+}
+/* Light sheen that sweeps across on hover */
+.btn-primary::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -120%;
+  width: 70%;
+  height: 100%;
+  background: linear-gradient(
+    100deg,
+    transparent,
+    rgba(255, 255, 255, 0.38),
+    transparent
+  );
+  transform: skewX(-18deg);
+  transition: left 0.7s var(--ease);
+  pointer-events: none;
+}
+.btn-primary:hover::before {
+  left: 130%;
+}
+.btn-primary:hover {
+  filter: brightness(1.05);
+  box-shadow: 0 10px 30px var(--accent-ring), inset 0 1px 0 rgba(255, 255, 255, 0.25);
+}
+.btn-ghost {
+  background: var(--surface);
+  color: var(--text-secondary);
+  border-color: var(--border);
+  box-shadow: var(--shadow-xs);
+}
+.btn-ghost:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+.btn-icon {
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border-radius: var(--r-md);
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color var(--dur) var(--ease), color var(--dur) var(--ease);
+}
+.btn-icon:hover {
+  background: var(--surface-2);
+  color: var(--text);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  padding: 4px 10px;
+  border-radius: var(--r-full);
+  line-height: 1;
+}
+
+.avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #fff;
+  border-radius: var(--r-full);
+  border: 2px solid var(--surface);
+  letter-spacing: 0.02em;
+}
+
+/* ----------------------------------------------------------------------- */
+/* Motion                                                                   */
+/* ----------------------------------------------------------------------- */
+@keyframes fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@keyframes pop-in {
+  0% { opacity: 0; transform: scale(0.94); }
+  100% { opacity: 1; transform: scale(1); }
+}
+@keyframes shimmer {
+  100% { transform: translateX(100%); }
+}
+@keyframes float-orb {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  50% { transform: translate(20px, -24px) scale(1.06); }
+}
+@keyframes float-orb-2 {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  50% { transform: translate(-26px, 18px) scale(1.1); }
+}
+/* Drawn check: the tick paints itself in */
+@keyframes check-draw {
+  from { stroke-dashoffset: 26; }
+  to { stroke-dashoffset: 0; }
+}
+/* Satisfying completion pop on the toggle control */
+@keyframes check-pop {
+  0% { transform: scale(1); }
+  40% { transform: scale(1.18); }
+  100% { transform: scale(1); }
+}
+/* A new card arrives with a brief accent halo, then settles */
+@keyframes card-intro {
+  0% { opacity: 0; transform: translateY(10px) scale(0.96); box-shadow: 0 0 0 3px var(--accent-ring); }
+  60% { opacity: 1; }
+  100% { opacity: 1; transform: translateY(0) scale(1); box-shadow: 0 0 0 0 transparent; }
+}
+
+/* Any drawn checkmark (Icon name="check") paints in when it appears */
+.draw-check svg path,
+.row__check svg path {
+  stroke-dasharray: 26;
+  animation: check-draw 0.4s var(--ease) forwards;
+}
+
+.anim-fade-up {
+  animation: fade-up 0.55s var(--ease) both;
+}
+.anim-fade-in {
+  animation: fade-in 0.5s var(--ease) both;
+}
+.anim-pop {
+  animation: pop-in 0.4s var(--ease) both;
+}
+
+/* Stagger helpers */
+.stagger > * {
+  animation: fade-up 0.5s var(--ease) both;
+}
+.stagger > *:nth-child(1) { animation-delay: 0.04s; }
+.stagger > *:nth-child(2) { animation-delay: 0.1s; }
+.stagger > *:nth-child(3) { animation-delay: 0.16s; }
+.stagger > *:nth-child(4) { animation-delay: 0.22s; }
+.stagger > *:nth-child(5) { animation-delay: 0.28s; }
+.stagger > *:nth-child(6) { animation-delay: 0.34s; }
+.stagger > *:nth-child(7) { animation-delay: 0.4s; }
+.stagger > *:nth-child(8) { animation-delay: 0.46s; }
+
+/* Vue list transitions (FLIP). Entering nodes (new tasks) get the crafted
+   halo intro; leaving + reordering use smooth springy motion. */
+.list-enter-active {
+  animation: card-intro 0.5s var(--ease) both;
+}
+.list-leave-active {
+  transition: opacity 0.32s var(--ease), transform 0.32s var(--ease);
+  position: absolute;
+  width: calc(100% - 4px);
+}
+.list-leave-to {
+  opacity: 0;
+  transform: translateY(10px) scale(0.96);
+}
+.list-move {
+  transition: transform 0.45s var(--spring);
+}
+
+/* Page / layout transitions */
+.slide-fade-enter-active {
+  transition: opacity 0.35s var(--ease), transform 0.35s var(--ease);
+}
+.slide-fade-leave-active {
+  transition: opacity 0.2s var(--ease), transform 0.2s var(--ease);
+}
+.slide-fade-enter {
+  opacity: 0;
+  transform: translateY(10px);
+}
+.slide-fade-leave-to {
+  opacity: 0;
+  transform: translateY(-6px);
+}
+.layout-enter-active,
+.layout-leave-active {
+  transition: opacity 0.3s var(--ease);
+}
+.layout-enter,
+.layout-leave-to {
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/components/AnimatedNumber.vue
+++ b/components/AnimatedNumber.vue
@@ -1,0 +1,48 @@
+<template>
+  <span>{{ display }}{{ suffix }}</span>
+</template>
+
+<script>
+export default {
+  name: 'AnimatedNumber',
+  props: {
+    value: { type: Number, default: 0 },
+    duration: { type: Number, default: 900 },
+    suffix: { type: String, default: '' },
+  },
+  data() {
+    return { display: 0, raf: null, start: 0, from: 0 }
+  },
+  watch: {
+    value(next, prev) {
+      this.animate(prev, next)
+    },
+  },
+  mounted() {
+    this.animate(0, this.value)
+  },
+  beforeDestroy() {
+    if (this.raf) cancelAnimationFrame(this.raf)
+  },
+  methods: {
+    animate(from, to) {
+      if (
+        window.matchMedia &&
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      ) {
+        this.display = to
+        return
+      }
+      if (this.raf) cancelAnimationFrame(this.raf)
+      const begin = performance.now()
+      const ease = (t) => 1 - Math.pow(1 - t, 3)
+      const step = (now) => {
+        const t = Math.min((now - begin) / this.duration, 1)
+        this.display = Math.round(from + (to - from) * ease(t))
+        if (t < 1) this.raf = requestAnimationFrame(step)
+      }
+      this.raf = requestAnimationFrame(step)
+    },
+  },
+}
+</script>

--- a/components/Icon.vue
+++ b/components/Icon.vue
@@ -1,0 +1,92 @@
+<template>
+  <svg
+    :width="size"
+    :height="size"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    :stroke-width="strokeWidth"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+    class="icon"
+    v-html="path"
+  />
+</template>
+
+<script>
+const ICONS = {
+  home: '<path d="M3 10.5 12 3l9 7.5"/><path d="M5 9.5V20a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V9.5"/><path d="M9.5 21v-6h5v6"/>',
+  board:
+    '<rect x="3" y="3" width="7" height="18" rx="1.5"/><rect x="14" y="3" width="7" height="11" rx="1.5"/>',
+  inbox:
+    '<path d="M22 12h-6l-2 3h-4l-2-3H2"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11Z"/>',
+  calendar:
+    '<rect x="3" y="4.5" width="18" height="16" rx="2"/><path d="M3 9h18M8 2.5v4M16 2.5v4"/>',
+  chart:
+    '<path d="M3 3v18h18"/><path d="M7 14l3-3 3 3 5-6"/>',
+  star: '<path d="M12 2.5l2.9 6.05 6.6.9-4.8 4.6 1.2 6.55L12 18.5l-5.9 3.15 1.2-6.55-4.8-4.6 6.6-.9Z"/>',
+  folder:
+    '<path d="M3 7.5A1.5 1.5 0 0 1 4.5 6h4l2 2.5h7A1.5 1.5 0 0 1 19 10v7.5A1.5 1.5 0 0 1 17.5 19h-13A1.5 1.5 0 0 1 3 17.5Z"/>',
+  message:
+    '<path d="M21 11.5a8.38 8.38 0 0 1-9 8.4 9.5 9.5 0 0 1-4-.9L3 21l1.9-4.5A8.38 8.38 0 0 1 4 11.5 8.5 8.5 0 0 1 12.5 3 8.38 8.38 0 0 1 21 11.5Z"/>',
+  settings:
+    '<circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z"/>',
+  logout:
+    '<path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><path d="M16 17l5-5-5-5M21 12H9"/>',
+  search: '<circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/>',
+  bell: '<path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.7 21a2 2 0 0 1-3.4 0"/>',
+  help: '<circle cx="12" cy="12" r="9"/><path d="M9.1 9a3 3 0 0 1 5.8 1c0 2-3 3-3 3"/><path d="M12 17h.01"/>',
+  plus: '<path d="M12 5v14M5 12h14"/>',
+  check: '<path d="M20 6 9 17l-5-5"/>',
+  trash:
+    '<path d="M3 6h18M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2m2 0v14a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V6"/><path d="M10 11v6M14 11v6"/>',
+  x: '<path d="M18 6 6 18M6 6l12 12"/>',
+  'chevron-down': '<path d="m6 9 6 6 6-6"/>',
+  'chevron-right': '<path d="m9 6 6 6-6 6"/>',
+  sun: '<circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/>',
+  moon: '<path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z"/>',
+  menu: '<path d="M3 6h18M3 12h18M3 18h18"/>',
+  grip: '<circle cx="9" cy="6" r="1"/><circle cx="9" cy="12" r="1"/><circle cx="9" cy="18" r="1"/><circle cx="15" cy="6" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="18" r="1"/>',
+  clock: '<circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/>',
+  more: '<circle cx="5" cy="12" r="1.4"/><circle cx="12" cy="12" r="1.4"/><circle cx="19" cy="12" r="1.4"/>',
+  'arrow-right': '<path d="M5 12h14M13 6l6 6-6 6"/>',
+  edit: '<path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/>',
+  flag: '<path d="M4 22V4M4 4l8-1 8 1v10l-8-1-8 1"/>',
+  sparkles:
+    '<path d="M12 3l1.8 4.7L18.5 9.5 13.8 11.3 12 16l-1.8-4.7L5.5 9.5l4.7-1.8Z"/><path d="M19 14l.7 1.8 1.8.7-1.8.7-.7 1.8-.7-1.8-1.8-.7 1.8-.7Z"/>',
+  list: '<path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01"/>',
+  layers:
+    '<path d="m12 2 9 5-9 5-9-5 9-5Z"/><path d="m3 12 9 5 9-5M3 17l9 5 9-5"/>',
+  filter: '<path d="M22 3H2l8 9.5V19l4 2v-8.5L22 3Z"/>',
+  info: '<circle cx="12" cy="12" r="9"/><path d="M12 11v5M12 8h.01"/>',
+  circle: '<circle cx="12" cy="12" r="9"/>',
+  'check-circle':
+    '<path d="M21 11.1V12a9 9 0 1 1-5.3-8.2"/><path d="m9 11 3 3 8.5-8.5"/>',
+  'arrow-left': '<path d="M19 12H5M11 18l-6-6 6-6"/>',
+  user: '<circle cx="12" cy="8" r="4"/><path d="M4 21a8 8 0 0 1 16 0"/>',
+  tag: '<path d="M3 3h7l11 11-7 7L3 10Z"/><circle cx="7.5" cy="7.5" r="1.5"/>',
+}
+
+export default {
+  name: 'Icon',
+  props: {
+    name: { type: String, required: true },
+    size: { type: [Number, String], default: 20 },
+    strokeWidth: { type: [Number, String], default: 1.9 },
+  },
+  computed: {
+    path() {
+      return ICONS[this.name] || ICONS.circle
+    },
+  },
+}
+</script>
+
+<style scoped>
+.icon {
+  display: inline-block;
+  flex: none;
+  vertical-align: middle;
+}
+</style>

--- a/components/TaskCard.vue
+++ b/components/TaskCard.vue
@@ -1,0 +1,311 @@
+<template>
+  <article
+    class="card"
+    :class="[`prio-${task.priority}`, { 'is-done': task.status === 'done', 'is-dragging': dragging }]"
+    draggable="true"
+    @dragstart="onDragStart"
+    @dragend="onDragEnd"
+  >
+    <span class="card__rail"></span>
+
+    <header class="card__top">
+      <div class="card__tags">
+        <span v-for="tag in task.tags" :key="tag" class="chip card__tag">{{ tag }}</span>
+        <span v-if="!task.tags.length" class="chip card__tag card__tag--empty">Task</span>
+      </div>
+      <div class="card__actions">
+        <button
+          class="card__act"
+          type="button"
+          :aria-label="task.status === 'done' ? 'Mark as not done' : 'Mark as done'"
+          @click="$emit('toggle', task)"
+        >
+          <Icon :name="task.status === 'done' ? 'check-circle' : 'circle'" :size="18" />
+        </button>
+        <button class="card__act card__act--danger" type="button" aria-label="Delete task" @click="$emit('remove', task.id)">
+          <Icon name="trash" :size="16" />
+        </button>
+        <span class="card__grip" aria-hidden="true"><Icon name="grip" :size="16" /></span>
+      </div>
+    </header>
+
+    <h4 class="card__title">{{ task.title }}</h4>
+    <p v-if="task.description" class="card__desc">{{ task.description }}</p>
+
+    <footer class="card__foot">
+      <div class="card__avatars">
+        <span
+          v-for="(a, i) in task.assignees"
+          :key="a + i"
+          class="avatar card__avatar"
+          :style="avatarStyle(a)"
+        >{{ a }}</span>
+        <span v-if="!task.assignees.length" class="card__avatar card__avatar--add">
+          <Icon name="plus" :size="14" />
+        </span>
+      </div>
+
+      <div class="card__meta">
+        <span class="card__prio" :title="task.priority + ' priority'">
+          <Icon name="flag" :size="13" :stroke-width="2.4" />
+          {{ task.priority }}
+        </span>
+        <button
+          v-if="task.status !== 'done'"
+          class="card__next"
+          type="button"
+          :aria-label="nextLabel"
+          @click="$emit('advance', task)"
+        >
+          <Icon name="arrow-right" :size="15" />
+        </button>
+      </div>
+    </footer>
+  </article>
+</template>
+
+<script>
+const PALETTE = [
+  ['#6366f1', '#8b5cf6'],
+  ['#0ea5e9', '#22d3ee'],
+  ['#f43f5e', '#fb7185'],
+  ['#10b981', '#34d399'],
+  ['#f59e0b', '#fbbf24'],
+  ['#8b5cf6', '#d946ef'],
+]
+
+export default {
+  name: 'TaskCard',
+  props: {
+    task: { type: Object, required: true },
+  },
+  data() {
+    return { dragging: false }
+  },
+  computed: {
+    nextLabel() {
+      return this.task.status === 'todo' ? 'Move to In progress' : 'Mark complete'
+    },
+  },
+  methods: {
+    avatarStyle(initials) {
+      let sum = 0
+      for (let i = 0; i < initials.length; i++) sum += initials.charCodeAt(i)
+      const [a, b] = PALETTE[sum % PALETTE.length]
+      return { backgroundImage: `linear-gradient(135deg, ${a}, ${b})` }
+    },
+    onDragStart(e) {
+      this.dragging = true
+      this.$emit('dragstart', this.task)
+      if (e.dataTransfer) {
+        e.dataTransfer.effectAllowed = 'move'
+        try {
+          e.dataTransfer.setData('text/plain', this.task.id)
+        } catch (err) {
+          /* ignore */
+        }
+      }
+    },
+    onDragEnd() {
+      this.dragging = false
+      this.$emit('dragend', this.task)
+    },
+  },
+}
+</script>
+
+<style scoped>
+.card {
+  position: relative;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: 14px 15px 13px 17px;
+  box-shadow: var(--shadow-sm), inset 0 1px 0 var(--inset-hi);
+  cursor: grab;
+  overflow: hidden;
+  transition: box-shadow var(--dur) var(--ease), transform var(--dur) var(--ease),
+    border-color var(--dur) var(--ease), opacity var(--dur) var(--ease);
+}
+.card:hover {
+  box-shadow: var(--shadow-lg), inset 0 1px 0 var(--inset-hi);
+  transform: translateY(-3px);
+  border-color: var(--border-strong);
+}
+.card:active {
+  cursor: grabbing;
+}
+.card.is-dragging {
+  opacity: 0.45;
+  transform: scale(0.98) rotate(-1deg);
+}
+
+.card__rail {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  border-radius: 4px 0 0 4px;
+}
+.prio-high .card__rail { background: var(--p-high); }
+.prio-medium .card__rail { background: var(--p-medium); }
+.prio-low .card__rail { background: var(--p-low); }
+
+.card__top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 9px;
+}
+.card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.card__tag {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+.card__tag--empty {
+  background: var(--surface-2);
+  color: var(--text-muted);
+}
+
+.card__actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex: none;
+}
+.card__act {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0;
+  transform: translateY(-2px);
+  transition: opacity var(--dur) var(--ease), color var(--dur) var(--ease),
+    background-color var(--dur) var(--ease), transform var(--dur) var(--ease);
+}
+.card:hover .card__act {
+  opacity: 1;
+  transform: translateY(0);
+}
+.card__act:hover {
+  background: var(--surface-2);
+  color: var(--text);
+}
+.card__act--danger:hover {
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--p-high);
+}
+.is-done .card__act:first-of-type {
+  opacity: 1;
+  color: var(--c-done);
+  animation: check-pop 0.42s var(--spring);
+}
+.card__grip {
+  color: var(--text-muted);
+  opacity: 0;
+  margin-left: 1px;
+  transition: opacity var(--dur) var(--ease);
+}
+.card:hover .card__grip {
+  opacity: 0.6;
+}
+
+.card__title {
+  font-size: 0.96rem;
+  font-weight: 600;
+  line-height: 1.35;
+  color: var(--text);
+}
+.is-done .card__title {
+  text-decoration: line-through;
+  text-decoration-color: var(--text-muted);
+  color: var(--text-secondary);
+}
+.card__desc {
+  margin: 6px 0 0;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.card__foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 13px;
+}
+.card__avatars {
+  display: flex;
+  align-items: center;
+}
+.card__avatar {
+  width: 28px;
+  height: 28px;
+}
+.card__avatar + .card__avatar {
+  margin-left: -8px;
+}
+.card__avatar--add {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1.5px dashed var(--border-strong);
+  border-radius: 9999px;
+  color: var(--text-muted);
+}
+
+.card__meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.card__prio {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: capitalize;
+  color: var(--text-muted);
+}
+.prio-high .card__prio { color: var(--p-high); }
+.prio-medium .card__prio { color: var(--p-medium); }
+.prio-low .card__prio { color: var(--p-low); }
+
+.card__next {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text-secondary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color var(--dur) var(--ease), color var(--dur) var(--ease),
+    border-color var(--dur) var(--ease), transform 0.4s var(--spring);
+}
+.card__next:hover {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+  transform: translateX(4px);
+}
+</style>

--- a/components/TaskColumn.vue
+++ b/components/TaskColumn.vue
@@ -1,0 +1,255 @@
+<template>
+  <section
+    class="column"
+    :class="{ 'is-over': isOver }"
+    @dragover.prevent="onDragOver"
+    @dragleave="onDragLeave"
+    @drop.prevent="onDrop"
+  >
+    <header class="column__head">
+      <div class="column__title">
+        <span class="column__dot" :style="{ background: color }"></span>
+        <h3>{{ title }}</h3>
+        <span class="column__count">{{ tasks.length }}</span>
+      </div>
+      <button class="column__add-btn" type="button" aria-label="Add task" @click="startAdd">
+        <Icon name="plus" :size="17" />
+      </button>
+    </header>
+
+    <transition name="composer">
+      <div v-if="adding" class="composer">
+        <input
+          ref="input"
+          v-model="draft"
+          class="composer__input"
+          type="text"
+          placeholder="Task title…"
+          @keyup.enter="commit"
+          @keyup.esc="cancelAdd"
+          @blur="cancelAdd"
+        />
+        <div class="composer__hint">
+          <span>Enter to add</span>
+          <span>Esc to cancel</span>
+        </div>
+      </div>
+    </transition>
+
+    <transition-group tag="div" name="list" class="column__list">
+      <TaskCard
+        v-for="task in tasks"
+        :key="task.id"
+        :task="task"
+        @toggle="$emit('toggle', $event)"
+        @remove="$emit('remove', $event)"
+        @advance="$emit('advance', $event)"
+        @dragstart="$emit('card-dragstart', $event)"
+        @dragend="$emit('card-dragend', $event)"
+      />
+      <div v-if="!tasks.length" key="__empty" class="column__empty">
+        <span class="column__empty-icon" :style="{ color }">
+          <Icon name="layers" :size="22" />
+        </span>
+        <p>No tasks here yet</p>
+        <button class="column__empty-add" type="button" @click="startAdd">Add one</button>
+      </div>
+    </transition-group>
+  </section>
+</template>
+
+<script>
+export default {
+  name: 'TaskColumn',
+  props: {
+    statusKey: { type: String, required: true },
+    title: { type: String, required: true },
+    color: { type: String, default: 'var(--accent)' },
+    tasks: { type: Array, default: () => [] },
+    isOver: { type: Boolean, default: false },
+  },
+  data() {
+    return { adding: false, draft: '' }
+  },
+  methods: {
+    startAdd() {
+      this.adding = true
+      this.$nextTick(() => this.$refs.input && this.$refs.input.focus())
+    },
+    commit() {
+      const title = this.draft.trim()
+      if (title) this.$emit('add', { title, status: this.statusKey })
+      this.draft = ''
+      this.adding = false
+    },
+    cancelAdd() {
+      // allow the click on commit/enter to register before closing
+      setTimeout(() => {
+        this.adding = false
+        this.draft = ''
+      }, 120)
+    },
+    onDragOver() {
+      this.$emit('over', this.statusKey)
+    },
+    onDragLeave(e) {
+      // only clear when leaving the column entirely
+      if (!e.currentTarget.contains(e.relatedTarget)) {
+        this.$emit('leave', this.statusKey)
+      }
+    },
+    onDrop() {
+      this.$emit('drop', this.statusKey)
+    },
+  },
+}
+</script>
+
+<style scoped>
+.column {
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(
+    180deg,
+    var(--surface) 0%,
+    var(--surface-2) 46%
+  );
+  border: 1px solid var(--border);
+  border-radius: var(--r-xl);
+  padding: 14px 12px;
+  min-height: 240px;
+  box-shadow: var(--shadow-xs), inset 0 1px 0 var(--inset-hi);
+  transition: background-color var(--dur) var(--ease),
+    border-color var(--dur) var(--ease), box-shadow var(--dur) var(--ease);
+}
+.column.is-over {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  box-shadow: inset 0 0 0 1px var(--accent-ring);
+}
+
+.column__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2px 6px 12px;
+}
+.column__title {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+.column__dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 9999px;
+}
+.column__title h3 {
+  font-size: 0.92rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.column__count {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 9999px;
+  padding: 1px 9px;
+  line-height: 1.5;
+}
+.column__add-btn {
+  width: 30px;
+  height: 30px;
+  border-radius: 9px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color var(--dur) var(--ease), color var(--dur) var(--ease);
+}
+.column__add-btn:hover {
+  background: var(--surface);
+  color: var(--accent);
+}
+
+.column__list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  position: relative;
+  padding: 2px;
+}
+
+.composer {
+  margin: 0 2px 10px;
+}
+.composer__input {
+  width: 100%;
+  height: 42px;
+  padding: 0 13px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--accent);
+  background: var(--surface);
+  color: var(--text);
+  font-size: 0.9rem;
+  font-family: inherit;
+  box-shadow: 0 0 0 4px var(--accent-soft);
+}
+.composer__input:focus {
+  outline: none;
+}
+.composer__hint {
+  display: flex;
+  gap: 12px;
+  margin-top: 6px;
+  padding: 0 4px;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+.composer-enter-active,
+.composer-leave-active {
+  transition: opacity 0.25s var(--ease), transform 0.25s var(--ease);
+}
+.composer-enter,
+.composer-leave-to {
+  opacity: 0;
+  transform: translateY(-6px);
+}
+
+.column__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 26px 10px;
+  text-align: center;
+  border: 1.5px dashed var(--border-strong);
+  border-radius: var(--r-lg);
+  color: var(--text-muted);
+}
+.column__empty-icon {
+  opacity: 0.6;
+}
+.column__empty p {
+  margin: 0;
+  font-size: 0.82rem;
+}
+.column__empty-add {
+  border: 0;
+  background: none;
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 0.82rem;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 6px;
+}
+.column__empty-add:hover {
+  text-decoration: underline;
+}
+</style>

--- a/components/TheSidebar.vue
+++ b/components/TheSidebar.vue
@@ -1,0 +1,277 @@
+<template>
+  <aside class="sidebar" :class="{ 'is-open': open }">
+    <div class="sidebar__brand">
+      <span class="sidebar__logo">
+        <Icon name="layers" :size="20" :stroke-width="2.2" />
+      </span>
+      <span class="sidebar__brand-text">
+        Tasks<span class="sidebar__brand-dot">.</span>
+      </span>
+    </div>
+
+    <nav class="sidebar__nav">
+      <p class="sidebar__label">Workspace</p>
+      <NuxtLink
+        v-for="item in items"
+        :key="item.to"
+        :to="item.to"
+        class="nav-item"
+        active-class="is-active"
+        :exact="item.exact"
+        @click.native="$emit('navigate')"
+      >
+        <span class="nav-item__icon"><Icon :name="item.icon" :size="19" /></span>
+        <span class="nav-item__text">{{ item.title }}</span>
+        <span v-if="item.badge" class="nav-item__badge">{{ item.badge }}</span>
+      </NuxtLink>
+    </nav>
+
+    <div class="sidebar__progress surface-card">
+      <div class="sidebar__progress-head">
+        <span>Weekly progress</span>
+        <strong>{{ progress }}%</strong>
+      </div>
+      <div class="bar">
+        <div class="bar__fill" :style="{ width: barWidth + '%' }"></div>
+      </div>
+      <p class="sidebar__progress-sub">{{ doneCount }} of {{ total }} tasks done</p>
+    </div>
+
+    <div class="sidebar__foot">
+      <div class="nav-item nav-item--muted">
+        <span class="nav-item__icon"><Icon name="settings" :size="19" /></span>
+        <span class="nav-item__text">Settings</span>
+      </div>
+      <div class="nav-item nav-item--muted">
+        <span class="nav-item__icon"><Icon name="logout" :size="19" /></span>
+        <span class="nav-item__text">Log out</span>
+      </div>
+    </div>
+  </aside>
+</template>
+
+<script>
+export default {
+  name: 'TheSidebar',
+  props: {
+    open: { type: Boolean, default: false },
+  },
+  data() {
+    return {
+      barWidth: 0,
+      items: [
+        { title: 'Today', to: '/', icon: 'home', exact: true },
+        { title: 'Board', to: '/todos', icon: 'board', exact: false },
+        { title: 'New task', to: '/addTask', icon: 'plus', exact: false },
+        { title: 'About', to: '/about', icon: 'info', exact: false },
+      ],
+    }
+  },
+  watch: {
+    progress(val) {
+      this.barWidth = val
+    },
+  },
+  mounted() {
+    this.$nextTick(() => {
+      window.requestAnimationFrame(() => {
+        this.barWidth = this.progress
+      })
+    })
+  },
+  computed: {
+    progress() {
+      return this.$store.getters['todos/progress']
+    },
+    doneCount() {
+      return this.$store.getters['todos/count']('done')
+    },
+    total() {
+      return this.$store.getters['todos/total']
+    },
+  },
+}
+</script>
+
+<style scoped>
+.sidebar {
+  width: 248px;
+  height: 100vh;
+  position: sticky;
+  top: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 22px 16px;
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+}
+
+.sidebar__brand {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 6px 8px 18px;
+}
+.sidebar__logo {
+  width: 38px;
+  height: 38px;
+  border-radius: 11px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  background: var(--accent-grad);
+  box-shadow: var(--shadow-accent);
+}
+.sidebar__brand-text {
+  font-family: var(--font-display);
+  font-size: 1.3rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+.sidebar__brand-dot {
+  color: var(--accent);
+}
+
+.sidebar__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.sidebar__label {
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  padding: 6px 10px;
+  margin: 4px 0 2px;
+}
+
+.nav-item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: var(--r-md);
+  color: var(--text-secondary);
+  font-weight: 500;
+  font-size: 0.93rem;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background-color var(--dur) var(--ease),
+    color var(--dur) var(--ease);
+}
+.nav-item__icon {
+  color: var(--text-muted);
+  display: inline-flex;
+  transition: color var(--dur) var(--ease), transform var(--dur) var(--ease);
+}
+.nav-item:hover {
+  background: var(--surface-2);
+  color: var(--text);
+}
+.nav-item:hover .nav-item__icon {
+  color: var(--text-secondary);
+  transform: translateX(1px);
+}
+.nav-item.is-active {
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 600;
+}
+.nav-item.is-active .nav-item__icon {
+  color: var(--accent);
+}
+.nav-item.is-active::before {
+  content: '';
+  position: absolute;
+  left: -16px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 22px;
+  border-radius: 0 4px 4px 0;
+  background: var(--accent);
+  animation: nav-indicator 0.4s var(--spring) both;
+}
+@keyframes nav-indicator {
+  from { transform: translateY(-50%) scaleY(0); opacity: 0; }
+  to { transform: translateY(-50%) scaleY(1); opacity: 1; }
+}
+.nav-item__text {
+  flex: 1;
+}
+.nav-item__badge {
+  font-size: 0.7rem;
+  font-weight: 700;
+  background: var(--accent);
+  color: #fff;
+  border-radius: 9999px;
+  padding: 2px 7px;
+  line-height: 1;
+}
+.nav-item--muted {
+  color: var(--text-muted);
+}
+
+.sidebar__progress {
+  margin-top: auto;
+  padding: 14px;
+  border-radius: var(--r-md);
+}
+.sidebar__progress-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  margin-bottom: 9px;
+}
+.sidebar__progress-head strong {
+  color: var(--text);
+  font-size: 0.95rem;
+}
+.bar {
+  height: 7px;
+  border-radius: 9999px;
+  background: var(--surface-3);
+  overflow: hidden;
+}
+.bar__fill {
+  height: 100%;
+  border-radius: 9999px;
+  background: var(--accent-grad);
+  transition: width 0.6s var(--ease);
+}
+.sidebar__progress-sub {
+  margin: 9px 0 0;
+  font-size: 0.74rem;
+  color: var(--text-muted);
+}
+
+.sidebar__foot {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding-top: 6px;
+}
+
+/* Mobile drawer */
+@media (max-width: 900px) {
+  .sidebar {
+    position: fixed;
+    z-index: 60;
+    left: 0;
+    top: 0;
+    transform: translateX(-100%);
+    transition: transform 0.35s var(--ease);
+    box-shadow: var(--shadow-xl);
+  }
+  .sidebar.is-open {
+    transform: translateX(0);
+  }
+}
+</style>

--- a/components/TheTopbar.vue
+++ b/components/TheTopbar.vue
@@ -1,0 +1,265 @@
+<template>
+  <header class="topbar">
+    <div class="topbar__left">
+      <button
+        class="btn-icon topbar__menu"
+        type="button"
+        aria-label="Open menu"
+        @click="$emit('toggle-sidebar')"
+      >
+        <Icon name="menu" :size="20" />
+      </button>
+      <div class="topbar__title">
+        <h1>{{ heading.title }}</h1>
+        <p>{{ heading.subtitle }}</p>
+      </div>
+    </div>
+
+    <div class="topbar__right">
+      <div class="search">
+        <span class="search__icon"><Icon name="search" :size="17" /></span>
+        <input
+          v-model="query"
+          type="text"
+          class="search__input"
+          placeholder="Search tasks…"
+          aria-label="Search tasks"
+        />
+        <kbd class="search__kbd">/</kbd>
+      </div>
+
+      <div class="locale" v-if="otherLocales.length">
+        <NuxtLink
+          v-for="locale in otherLocales"
+          :key="locale.code"
+          :to="switchLocalePath(locale.code)"
+          class="locale__item"
+          :title="locale.name"
+        >
+          <span :class="['flag-icon', `flag-icon-${locale.code}`]"></span>
+        </NuxtLink>
+      </div>
+
+      <ThemeToggle />
+
+      <button class="btn-icon topbar__bell" type="button" aria-label="Notifications">
+        <Icon name="bell" :size="19" />
+        <span class="topbar__dot"></span>
+      </button>
+
+      <button class="topbar__user" type="button">
+        <span class="topbar__avatar">CĐ</span>
+        <span class="topbar__user-name">Công Đạt</span>
+        <Icon name="chevron-down" :size="15" />
+      </button>
+    </div>
+  </header>
+</template>
+
+<script>
+const HEADINGS = {
+  '/': { title: 'Today', subtitle: "Here's what needs your attention" },
+  '/todos': { title: 'Board', subtitle: 'Drag tasks across your workflow' },
+  '/addTask': { title: 'New task', subtitle: 'Capture something to get done' },
+  '/about': { title: 'About', subtitle: 'A little about this project' },
+}
+
+export default {
+  name: 'TheTopbar',
+  data() {
+    return { query: '' }
+  },
+  computed: {
+    heading() {
+      return (
+        HEADINGS[this.$route.path] || {
+          title: 'Tasks',
+          subtitle: 'Stay on top of your work',
+        }
+      )
+    },
+    otherLocales() {
+      if (!this.$i18n) return []
+      return this.$i18n.locales.filter((l) => l.code !== this.$i18n.locale)
+    },
+  },
+}
+</script>
+
+<style scoped>
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px clamp(16px, 3vw, 36px);
+  background: color-mix(in srgb, var(--bg) 78%, transparent);
+  backdrop-filter: saturate(150%) blur(14px);
+  -webkit-backdrop-filter: saturate(150%) blur(14px);
+  border-bottom: 1px solid var(--border);
+}
+.topbar__left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+.topbar__menu {
+  display: none;
+}
+.topbar__title h1 {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 600;
+  line-height: 1.12;
+}
+.topbar__title p {
+  margin: 2px 0 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.topbar__right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.search {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+.search__icon {
+  position: absolute;
+  left: 13px;
+  color: var(--text-muted);
+  pointer-events: none;
+  display: inline-flex;
+}
+.search__input {
+  width: 240px;
+  height: 42px;
+  padding: 0 38px 0 38px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  font-size: 0.9rem;
+  font-family: inherit;
+  transition: border-color var(--dur) var(--ease),
+    box-shadow var(--dur) var(--ease), background-color var(--dur) var(--ease);
+}
+.search__input::placeholder {
+  color: var(--text-muted);
+}
+.search__input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px var(--accent-soft);
+}
+.search__kbd {
+  position: absolute;
+  right: 11px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 2px 7px;
+  line-height: 1.2;
+}
+
+.locale {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 4px;
+}
+.locale__item {
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.7;
+  transition: opacity var(--dur) var(--ease), background-color var(--dur) var(--ease);
+}
+.locale__item:hover {
+  opacity: 1;
+  background: var(--surface-2);
+}
+.locale__item .flag-icon {
+  border-radius: 3px;
+  box-shadow: var(--shadow-xs);
+}
+
+.topbar__bell {
+  position: relative;
+}
+.topbar__dot {
+  position: absolute;
+  top: 9px;
+  right: 10px;
+  width: 7px;
+  height: 7px;
+  border-radius: 9999px;
+  background: var(--p-high);
+  border: 2px solid var(--bg);
+}
+
+.topbar__user {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 5px 12px 5px 5px;
+  border-radius: var(--r-full);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: border-color var(--dur) var(--ease), background-color var(--dur) var(--ease);
+}
+.topbar__user:hover {
+  border-color: var(--border-strong);
+  background: var(--surface-hover);
+}
+.topbar__avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 9999px;
+  background: var(--accent-grad);
+  color: #fff;
+  font-size: 0.78rem;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.topbar__user-name {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+@media (max-width: 900px) {
+  .topbar__menu {
+    display: inline-flex;
+  }
+}
+@media (max-width: 720px) {
+  .search,
+  .locale,
+  .topbar__user-name {
+    display: none;
+  }
+  .topbar__title p {
+    display: none;
+  }
+}
+</style>

--- a/components/ThemeToggle.vue
+++ b/components/ThemeToggle.vue
@@ -1,0 +1,83 @@
+<template>
+  <button
+    class="theme-toggle"
+    type="button"
+    :aria-pressed="isDark"
+    :aria-label="isDark ? 'Switch to light mode' : 'Switch to dark mode'"
+    @click="toggle"
+  >
+    <span class="theme-toggle__track">
+      <span class="theme-toggle__thumb" :class="{ 'is-dark': isDark }">
+        <Icon :name="isDark ? 'moon' : 'sun'" :size="14" :stroke-width="2.2" />
+      </span>
+    </span>
+  </button>
+</template>
+
+<script>
+export default {
+  name: 'ThemeToggle',
+  data() {
+    return { isDark: false }
+  },
+  mounted() {
+    this.isDark = document.documentElement.classList.contains('dark')
+  },
+  methods: {
+    toggle() {
+      this.isDark = !this.isDark
+      const root = document.documentElement
+      root.classList.toggle('dark', this.isDark)
+      try {
+        localStorage.setItem('theme', this.isDark ? 'dark' : 'light')
+      } catch (e) {
+        /* ignore */
+      }
+    },
+  },
+}
+</script>
+
+<style scoped>
+.theme-toggle {
+  background: none;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  display: inline-flex;
+}
+.theme-toggle__track {
+  position: relative;
+  display: block;
+  width: 52px;
+  height: 28px;
+  border-radius: 9999px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  transition: background-color var(--dur) var(--ease),
+    border-color var(--dur) var(--ease);
+}
+.theme-toggle:hover .theme-toggle__track {
+  border-color: var(--border-strong);
+}
+.theme-toggle__thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 22px;
+  height: 22px;
+  border-radius: 9999px;
+  background: var(--surface);
+  color: #f59e0b;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--shadow-sm);
+  transform: translateX(0) rotate(0deg);
+  transition: transform 0.5s var(--spring), color var(--dur) var(--ease);
+}
+.theme-toggle__thumb.is-dark {
+  transform: translateX(24px) rotate(360deg);
+  color: var(--accent);
+}
+</style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,12 +1,77 @@
 <template>
-  <div class="mx-auto pl-20 grid grid-cols-12 gap-2">
-    <div class="col-start-1 col-end-2">
-      <TheNavbar />
-    </div>
-    <div class="col-start-3 col-end-12">
-      <TheHeader />
-      <Nuxt />
+  <div class="shell">
+    <TheSidebar :open="sidebarOpen" @navigate="sidebarOpen = false" />
+
+    <transition name="fade">
+      <div
+        v-if="sidebarOpen"
+        class="shell__overlay"
+        @click="sidebarOpen = false"
+      ></div>
+    </transition>
+
+    <div class="shell__main">
+      <TheTopbar @toggle-sidebar="sidebarOpen = !sidebarOpen" />
+      <main class="shell__content">
+        <Nuxt />
+      </main>
     </div>
   </div>
 </template>
-<script></script>
+
+<script>
+export default {
+  data() {
+    return { sidebarOpen: false }
+  },
+  watch: {
+    $route() {
+      this.sidebarOpen = false
+    },
+  },
+}
+</script>
+
+<style scoped>
+.shell {
+  display: flex;
+  min-height: 100vh;
+  width: 100%;
+}
+.shell__main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+.shell__content {
+  flex: 1;
+  padding: clamp(20px, 3vw, 36px);
+  width: 100%;
+  max-width: 1320px;
+  margin: 0 auto;
+}
+.shell__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  background: rgba(8, 10, 16, 0.45);
+  backdrop-filter: blur(2px);
+  display: none;
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.25s var(--ease);
+}
+.fade-enter,
+.fade-leave-to {
+  opacity: 0;
+}
+
+@media (max-width: 900px) {
+  .shell__overlay {
+    display: block;
+  }
+}
+</style>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,35 +1,55 @@
 export default {
   // Global page headers: https://go.nuxtjs.dev/config-head
   head: {
-    title: 'learn-nuxt-js',
+    title: 'Tasks — a calm task board',
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-      { hid: 'description', name: 'description', content: '' },
+      {
+        hid: 'description',
+        name: 'description',
+        content:
+          'Tasks — a minimal, premium kanban board built with Nuxt.js. Drag tasks across your workflow, in light or dark mode.',
+      },
       { name: 'format-detection', content: 'telephone=no' },
+      { name: 'theme-color', content: '#6366f1' },
     ],
     link: [
       { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
+      { rel: 'preconnect', href: 'https://api.fontshare.com' },
+      {
+        rel: 'preconnect',
+        href: 'https://cdn.fontshare.com',
+        crossorigin: true,
+      },
       {
         rel: 'stylesheet',
-        href: 'https://fonts.googleapis.com/css2?family=Poppins:wght@100;200;300;400;500;600;700;800;900&display=swap',
+        href: 'https://api.fontshare.com/v2/css?f[]=satoshi@400,500,700,900&f[]=clash-display@500,600,700&display=swap',
       },
       {
         rel: 'stylesheet',
         href: 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css',
       },
     ],
+    script: [
+      {
+        // Apply the saved/system theme before first paint to avoid a flash.
+        innerHTML:
+          "(function(){try{var t=localStorage.getItem('theme');if(!t){t=(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)?'dark':'light';}if(t==='dark'){document.documentElement.classList.add('dark');}}catch(e){}})();",
+      },
+    ],
+    __dangerouslyDisableSanitizers: ['script'],
   },
-  loading: '~/components/LoadingBar.vue',
+  loading: { color: '#6366f1', height: '2px' },
   loadingIndicator: {
     name: 'circle',
-    color: '#3B8070',
-    background: 'white',
+    color: '#6366f1',
+    background: '#f6f7f9',
   },
   // Global CSS: https://go.nuxtjs.dev/config-css
   css: [
-    '~/assets/styles/base.scss',
     '~/assets/styles/main.scss',
+    '~/assets/styles/theme.scss',
     '~/assets/fonts/flag-icon-css-master/css/flag-icon.min.css',
   ],
 
@@ -37,9 +57,7 @@ export default {
 
   pageTransition: {
     name: 'slide-fade',
-    beforeEnter(el) {
-      console.log('Before enter...', el)
-    },
+    mode: 'out-in',
   },
 
   // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins
@@ -48,6 +66,7 @@ export default {
     '~/plugins/vue-tooltip.js',
     '~/plugins/hello.js',
     '~/plugins/i18n.js',
+    '~/plugins/persist.client.js',
   ],
 
   // Auto import components: https://go.nuxtjs.dev/config-components

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -1,25 +1,228 @@
 <template>
-  <div class="about">
-    <h1 class="inline-block p-2">About Task</h1>
+  <div class="about anim-fade-in">
+    <section class="hero surface-card">
+      <span class="hero__badge">
+        <Icon name="sparkles" :size="14" /> Nuxt.js · learning project
+      </span>
+      <h1 class="hero__title">
+        A calm place to track<br />
+        <span class="hero__grad">everything you need to do.</span>
+      </h1>
+      <p class="hero__sub">
+        Tasks is a small kanban board built with Nuxt, Vuex and Tailwind — now
+        with a premium, fully-themeable interface. Add tasks, drag them across
+        your workflow, and your board is saved right in the browser.
+      </p>
+      <div class="hero__cta">
+        <NuxtLink to="/todos" class="btn btn-primary">
+          Open the board <Icon name="arrow-right" :size="18" />
+        </NuxtLink>
+        <NuxtLink to="/addTask" class="btn btn-ghost">
+          <Icon name="plus" :size="18" /> New task
+        </NuxtLink>
+      </div>
+    </section>
+
+    <section class="features stagger">
+      <article v-for="f in features" :key="f.title" class="feature surface-card">
+        <span class="feature__icon" :style="{ background: f.soft, color: f.color }">
+          <Icon :name="f.icon" :size="22" />
+        </span>
+        <h3>{{ f.title }}</h3>
+        <p>{{ f.body }}</p>
+      </article>
+    </section>
+
+    <section class="stack surface-card">
+      <span class="stack__label">Built with</span>
+      <div class="stack__chips">
+        <span v-for="t in tech" :key="t" class="chip stack__chip">{{ t }}</span>
+      </div>
+    </section>
   </div>
 </template>
 
-<script></script>
+<script>
+export default {
+  name: 'AboutPage',
+  data() {
+    return {
+      features: [
+        {
+          title: 'Drag & drop board',
+          body: 'Move tasks between To do, In progress and Completed with smooth, physical motion.',
+          icon: 'board',
+          color: 'var(--c-todo)',
+          soft: 'var(--c-todo-soft)',
+        },
+        {
+          title: 'Saved automatically',
+          body: 'Your tasks persist in localStorage, so the board is exactly how you left it.',
+          icon: 'check-circle',
+          color: 'var(--c-done)',
+          soft: 'var(--c-done-soft)',
+        },
+        {
+          title: 'Light & dark',
+          body: 'A carefully tuned palette for both modes, switchable any time from the top bar.',
+          icon: 'moon',
+          color: 'var(--c-progress)',
+          soft: 'var(--c-progress-soft)',
+        },
+      ],
+      tech: ['Nuxt.js', 'Vue', 'Vuex', 'Tailwind CSS', 'SCSS', 'i18n', 'PWA'],
+    }
+  },
+}
+</script>
 
-<style lang="scss" scoped>
+<style scoped>
 .about {
-  background: rgba(0, 0, 0, 0.07)
-    url('~/assets/images/VVS_PCWallpaper_Dark.png') no-repeat center center /
-    cover;
-  width: 100%;
-  height: 86vh;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  gap: 22px;
+  max-width: 920px;
+  margin: 0 auto;
+}
+
+.hero {
+  position: relative;
+  overflow: hidden;
+  padding: 44px clamp(24px, 5vw, 48px);
+  border-radius: var(--r-xl);
+}
+.hero::before {
+  content: '';
+  position: absolute;
+  top: -120px;
+  right: -80px;
+  width: 360px;
+  height: 360px;
+  border-radius: 9999px;
+  background: var(--accent-grad);
+  opacity: 0.16;
+  filter: blur(40px);
+  animation: float-orb 11s ease-in-out infinite;
+}
+.hero::after {
+  content: '';
+  position: absolute;
+  bottom: -140px;
+  left: -60px;
+  width: 280px;
+  height: 280px;
+  border-radius: 9999px;
+  background: radial-gradient(circle, var(--c-progress) 0%, transparent 70%);
+  opacity: 0.1;
+  filter: blur(44px);
+  animation: float-orb-2 13s ease-in-out infinite;
+}
+.hero__badge {
+  display: inline-flex;
   align-items: center;
-  h1 {
-    color: chocolate;
-    font-size: 32px;
-    font-weight: 700;
+  gap: 7px;
+  font-size: 0.76rem;
+  font-weight: 600;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border-radius: 9999px;
+  padding: 6px 13px;
+  margin-bottom: 18px;
+}
+.hero__title {
+  font-family: var(--font-display);
+  font-size: clamp(1.85rem, 4.4vw, 2.9rem);
+  font-weight: 600;
+  line-height: 1.08;
+  letter-spacing: -0.025em;
+}
+.hero__grad {
+  background: var(--accent-grad);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.hero__sub {
+  margin: 16px 0 0;
+  max-width: 560px;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+.hero__cta {
+  display: flex;
+  gap: 12px;
+  margin-top: 26px;
+  flex-wrap: wrap;
+}
+
+.features {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+.feature {
+  padding: 22px;
+  border-radius: var(--r-lg);
+  transition: transform var(--dur) var(--ease), box-shadow var(--dur) var(--ease);
+}
+.feature:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-lg);
+}
+.feature__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 14px;
+}
+.feature h3 {
+  font-family: var(--font-display);
+  font-size: 1.08rem;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+.feature p {
+  margin: 0;
+  font-size: 0.87rem;
+  line-height: 1.55;
+  color: var(--text-secondary);
+}
+
+.stack {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 18px 22px;
+  border-radius: var(--r-lg);
+}
+.stack__label {
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.stack__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.stack__chip {
+  background: var(--surface-2);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  font-size: 0.78rem;
+  padding: 6px 12px;
+}
+
+@media (max-width: 760px) {
+  .features {
+    grid-template-columns: 1fr;
   }
 }
 </style>

--- a/pages/addTask.vue
+++ b/pages/addTask.vue
@@ -1,39 +1,302 @@
 <template>
-  <div class="addTask">
-    <h1>Add Task</h1>
-    <ul>
-      <li v-for="todo in todos" :key="todo.text">
-        <input :checked="todo.done" @change="toggle(todo)" type="checkbox" />
-        <span :class="{ done: todo.done }">{{ todo.text }}</span>
-      </li>
-    </ul>
+  <div class="addpage anim-fade-in">
+    <form class="form surface-card" @submit.prevent="submit">
+      <div class="form__head">
+        <h2>Create a task</h2>
+        <p>Add the details and drop it straight onto your board.</p>
+      </div>
+
+      <label class="field">
+        <span class="field__label">Title</span>
+        <input
+          v-model="form.title"
+          class="field__input"
+          type="text"
+          placeholder="e.g. Polish the onboarding flow"
+          required
+        />
+      </label>
+
+      <label class="field">
+        <span class="field__label">Description <span class="field__opt">optional</span></span>
+        <textarea
+          v-model="form.description"
+          class="field__input field__textarea"
+          rows="3"
+          placeholder="Add any context, links or acceptance criteria…"
+        ></textarea>
+      </label>
+
+      <div class="field__row">
+        <div class="field">
+          <span class="field__label">Status</span>
+          <div class="seg">
+            <button
+              v-for="s in statuses"
+              :key="s.key"
+              type="button"
+              class="seg__btn"
+              :class="{ 'is-active': form.status === s.key }"
+              @click="form.status = s.key"
+            >
+              <span class="seg__dot" :style="{ background: s.color }"></span>{{ s.label }}
+            </button>
+          </div>
+        </div>
+
+        <div class="field">
+          <span class="field__label">Priority</span>
+          <div class="seg">
+            <button
+              v-for="p in priorities"
+              :key="p.key"
+              type="button"
+              class="seg__btn"
+              :class="{ 'is-active': form.priority === p.key }"
+              @click="form.priority = p.key"
+            >
+              <span class="seg__dot" :style="{ background: p.color }"></span>{{ p.label }}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <label class="field">
+        <span class="field__label">Tags <span class="field__opt">comma separated</span></span>
+        <input
+          v-model="tagInput"
+          class="field__input"
+          type="text"
+          placeholder="Design, Frontend"
+        />
+      </label>
+
+      <div class="form__foot">
+        <NuxtLink to="/todos" class="btn btn-ghost">Cancel</NuxtLink>
+        <button type="submit" class="btn btn-primary" :disabled="!form.title.trim()">
+          <Icon name="check" :size="18" /> Create task
+        </button>
+      </div>
+    </form>
+
+    <aside class="preview">
+      <span class="preview__label">Live preview</span>
+      <TaskCard :task="previewTask" class="preview__card" />
+    </aside>
   </div>
 </template>
 
 <script>
 export default {
+  name: 'AddTaskPage',
+  data() {
+    return {
+      form: {
+        title: '',
+        description: '',
+        status: 'todo',
+        priority: 'medium',
+      },
+      tagInput: '',
+      statuses: [
+        { key: 'todo', label: 'To do', color: 'var(--c-todo)' },
+        { key: 'progress', label: 'In progress', color: 'var(--c-progress)' },
+        { key: 'done', label: 'Done', color: 'var(--c-done)' },
+      ],
+      priorities: [
+        { key: 'low', label: 'Low', color: 'var(--p-low)' },
+        { key: 'medium', label: 'Medium', color: 'var(--p-medium)' },
+        { key: 'high', label: 'High', color: 'var(--p-high)' },
+      ],
+    }
+  },
   computed: {
-    todos() {
-      return this.$store.state.todos.list
+    tags() {
+      return this.tagInput
+        .split(',')
+        .map((t) => t.trim())
+        .filter(Boolean)
+    },
+    previewTask() {
+      return {
+        id: 'preview',
+        title: this.form.title.trim() || 'Your task title',
+        description: this.form.description.trim(),
+        status: this.form.status,
+        priority: this.form.priority,
+        tags: this.tags,
+        assignees: ['CĐ'],
+        createdAt: Date.now(),
+      }
+    },
+  },
+  methods: {
+    submit() {
+      if (!this.form.title.trim()) return
+      this.$store.commit('todos/add', {
+        ...this.form,
+        tags: this.tags,
+        assignees: ['CĐ'],
+      })
+      this.$router.push('/todos')
     },
   },
 }
 </script>
 
 <style scoped>
-.addTask {
-  background: rgba(0, 0, 0, 0.5)
-    url('~/assets/images/VVS_PCWallpaper_Light.png') no-repeat center center /
-    cover;
-  width: 100vw;
-  height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+.addpage {
+  display: grid;
+  grid-template-columns: 1fr 340px;
+  gap: 24px;
+  align-items: start;
+  max-width: 980px;
+  margin: 0 auto;
 }
-h1 {
-  color: chocolate;
-  font-size: 32px;
+
+.form {
+  padding: 26px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.form__head h2 {
+  font-family: var(--font-display);
+  font-size: 1.45rem;
+  font-weight: 600;
+}
+.form__head p {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 0.88rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+.field__label {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.field__opt {
+  font-weight: 500;
+  color: var(--text-muted);
+  font-size: 0.76rem;
+}
+.field__input {
+  width: 100%;
+  padding: 11px 14px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text);
+  font-size: 0.92rem;
+  font-family: inherit;
+  transition: border-color var(--dur) var(--ease), box-shadow var(--dur) var(--ease),
+    background-color var(--dur) var(--ease);
+}
+.field__input:focus {
+  outline: none;
+  border-color: var(--accent);
+  background: var(--surface);
+  box-shadow: 0 0 0 4px var(--accent-soft);
+}
+.field__input::placeholder {
+  color: var(--text-muted);
+}
+.field__textarea {
+  resize: vertical;
+  min-height: 84px;
+  line-height: 1.5;
+}
+.field__row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.seg {
+  display: flex;
+  gap: 6px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: 4px;
+}
+.seg__btn {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 4px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color var(--dur) var(--ease), color var(--dur) var(--ease),
+    box-shadow var(--dur) var(--ease);
+}
+.seg__btn:hover {
+  color: var(--text);
+}
+.seg__btn.is-active {
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: var(--shadow-sm);
+}
+.seg__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 9999px;
+}
+
+.form__foot {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 4px;
+}
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.preview {
+  position: sticky;
+  top: 92px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.preview__label {
+  font-size: 0.72rem;
   font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  padding-left: 2px;
+}
+.preview__card {
+  cursor: default;
+}
+
+@media (max-width: 860px) {
+  .addpage {
+    grid-template-columns: 1fr;
+  }
+  .preview {
+    position: static;
+  }
+  .field__row {
+    grid-template-columns: 1fr;
+  }
 }
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,265 +1,419 @@
 <template>
-  <div class="todos flex flex-col w-full mt-10">
-    <div class="todos__header flex flex-row justify-between items-center mb-5">
-      <h2 class="text-2xl font-medium">Projects</h2>
-      <div>
-        <span>This Week</span>
-        <i class="fas fa-chevron-down text-sm"></i>
+  <div class="today anim-fade-in">
+    <section class="quickadd surface-card">
+      <span class="quickadd__icon"><Icon name="sparkles" :size="20" /></span>
+      <input
+        v-model="draft"
+        class="quickadd__input"
+        type="text"
+        placeholder="What needs to be done today?"
+        @keyup.enter="add"
+      />
+      <button class="btn btn-primary" :disabled="!draft.trim()" @click="add">
+        <Icon name="plus" :size="18" /> Add task
+      </button>
+    </section>
+
+    <div class="today__head">
+      <div class="filters">
+        <button
+          v-for="f in filters"
+          :key="f.key"
+          class="filters__pill"
+          :class="{ 'is-active': filter === f.key }"
+          @click="filter = f.key"
+        >
+          {{ f.label }}
+          <span class="filters__num">{{ countFor(f.key) }}</span>
+        </button>
       </div>
+      <button v-if="doneCount" class="today__clear" @click="clearDone">
+        <Icon name="trash" :size="15" /> Clear completed
+      </button>
     </div>
 
-    <div class="todos__main grid grid-cols-3 gap-6 mb-6">
-      <div class="todo__item rounded-lg px-3">
-        <div class="flex justify-between items-center my-2">
-          <h3 class="my-1 font-medium">To do</h3>
-          <span class="bg-green-300 px-1.5 rounded-lg">2</span>
-        </div>
-
-        <div class="todo__item--add">
-          <i class="fas fa-plus"></i>
-        </div>
-
-        <div
-          class="todo__item--main flex flex-col bg-white rounded-lg my-3 p-3"
+    <transition-group tag="ul" name="list" class="task-list">
+      <li
+        v-for="task in filtered"
+        :key="task.id"
+        class="row"
+        :class="{ 'is-done': task.status === 'done' }"
+      >
+        <button
+          class="row__check"
+          :class="`prio-${task.priority}`"
+          type="button"
+          :aria-label="task.status === 'done' ? 'Mark incomplete' : 'Mark complete'"
+          @click="toggle(task)"
         >
-          <div
-            class="
-              todo__item-header
-              flex flex-row
-              justify-between
-              items-center
-              py-2
-            "
-          >
-            <h4 class="font-semibold">Desigin</h4>
-            <i class="fas fa-paperclip text-gray-400"></i>
-          </div>
+          <Icon v-if="task.status === 'done'" name="check" :size="14" :stroke-width="3" />
+        </button>
 
-          <div class="todo__item-content my-3">
-            <p>
-              We need 2 different concepts for a software page in our program.
-            </p>
-            <p class="my-2">
-              I've attached 2 concepts that will give you an idea to reproduce
-              but with a new look and feel. We'd like to keep the colors similar
-              but you can add different colors.
-            </p>
-          </div>
-
-          <div class="todo__item-relationship">
-            <span
-              class="
-                todo__item-person
-                inline-block
-                w-9
-                h-9
-                text-center
-                rounded-full
-              "
-              >TN</span
-            >
-            <span
-              class="
-                todo__item-person
-                bg-indigo-600
-                inline-block
-                w-9
-                h-9
-                text-center
-                rounded-full
-              "
-              >VE</span
-            >
+        <div class="row__body">
+          <span class="row__title">{{ task.title }}</span>
+          <div class="row__meta">
+            <span v-for="tag in task.tags" :key="tag" class="chip row__tag">{{ tag }}</span>
+            <span class="row__status" :data-s="task.status">{{ statusLabel(task.status) }}</span>
           </div>
         </div>
-        <div
-          class="todo__item--main flex flex-col bg-white rounded-lg my-3 p-3"
-        >
-          <div
-            class="
-              todo__item-header
-              flex flex-row
-              justify-between
-              items-center
-              py-2
-            "
-          >
-            <h4 class="font-semibold">Development</h4>
-            <i class="fas fa-paperclip text-gray-400"></i>
-          </div>
 
-          <div class="todo__item-content my-3">
-            <p class="my-2">
-              Secured web platform that will integrate and pull data from
-              several other web apps to which I subscribe and have the api
-              access to.
-            </p>
-          </div>
-
-          <div class="todo__item-relationship">
-            <span
-              class="
-                todo__item-person
-                inline-block
-                w-9
-                h-9
-                text-center
-                rounded-full
-              "
-              >JE</span
-            >
-          </div>
-        </div>
-      </div>
-
-      <div class="todo__item rounded-lg px-3">
-        <div class="flex justify-between items-center my-2">
-          <h3 class="my-1 font-medium">In process</h3>
-          <span class="bg-green-300 px-1.5 rounded-lg">2</span>
+        <div class="row__avatars">
+          <span
+            v-for="(a, i) in task.assignees"
+            :key="a + i"
+            class="avatar row__avatar"
+            :style="avatarStyle(a)"
+          >{{ a }}</span>
         </div>
 
-        <div class="todo__item--add">
-          <i class="fas fa-plus"></i>
-        </div>
+        <button class="row__del" type="button" aria-label="Delete" @click="remove(task.id)">
+          <Icon name="trash" :size="16" />
+        </button>
+      </li>
 
-        <div
-          class="todo__item--main flex flex-col bg-white rounded-lg my-3 p-3"
-        >
-          <div
-            class="
-              todo__item-header
-              flex flex-row
-              justify-between
-              items-center
-              py-2
-            "
-          >
-            <h4 class="font-semibold">Development</h4>
-            <i class="fas fa-paperclip text-gray-400"></i>
-          </div>
-
-          <div class="todo__item-content my-3">
-            <p class="my-2">
-              Dynamic links to work with our iOS and Android apps.
-            </p>
-          </div>
-
-          <div class="todo__item-relationship">
-            <span
-              class="
-                todo__item-person
-                inline-block
-                w-9
-                h-9
-                text-center
-                rounded-full
-              "
-              >SW</span
-            >
-            <span
-              class="
-                todo__item-person
-                bg-indigo-600
-                inline-block
-                w-9
-                h-9
-                text-center
-                rounded-full
-              "
-              >GJ</span
-            >
-          </div>
-        </div>
-        <div
-          class="todo__item--main flex flex-col bg-white rounded-lg my-3 p-3"
-        >
-          <div
-            class="
-              todo__item-header
-              flex flex-row
-              justify-between
-              items-center
-              py-2
-            "
-          >
-            <h4 class="font-semibold">Logo redisign</h4>
-            <i class="fas fa-paperclip text-gray-400"></i>
-          </div>
-
-          <div class="todo__item-content my-3">
-            <p class="my-2">
-              An existing redesign. The logo includes shading from light red to
-              red, and I want to keep the exact shape, but make it one solid
-              color.
-            </p>
-          </div>
-
-          <div class="todo__item-relationship">
-            <span
-              class="
-                todo__item-person
-                inline-block
-                w-9
-                h-9
-                text-center
-                rounded-full
-              "
-              >AV</span
-            >
-            <span
-              class="
-                todo__item-person
-                bg-indigo-600
-                inline-block
-                w-9
-                h-9
-                text-center
-                rounded-full
-              "
-              >TN</span
-            >
-          </div>
-        </div>
-      </div>
-
-      <div class="todo__item rounded-lg px-3">
-        <div class="flex justify-between items-center my-2">
-          <h3 class="my-1 font-medium">Completed</h3>
-          <span class="bg-green-300 px-1.5 rounded-lg">0</span>
-        </div>
-
-        <div class="todo__item--add">
-          <i class="fas fa-plus"></i>
-        </div>
-      </div>
-    </div>
+      <li v-if="!filtered.length" key="__empty" class="empty">
+        <span class="empty__icon"><Icon name="check-circle" :size="30" /></span>
+        <h3>{{ emptyHeading }}</h3>
+        <p>{{ emptySub }}</p>
+      </li>
+    </transition-group>
   </div>
 </template>
 
 <script>
-export default {}
+const PALETTE = [
+  ['#6366f1', '#8b5cf6'],
+  ['#0ea5e9', '#22d3ee'],
+  ['#f43f5e', '#fb7185'],
+  ['#10b981', '#34d399'],
+  ['#f59e0b', '#fbbf24'],
+]
+
+export default {
+  name: 'TodayPage',
+  data() {
+    return {
+      draft: '',
+      filter: 'all',
+      filters: [
+        { key: 'all', label: 'All' },
+        { key: 'active', label: 'Active' },
+        { key: 'done', label: 'Completed' },
+      ],
+    }
+  },
+  computed: {
+    tasks() {
+      return this.$store.state.todos.tasks
+    },
+    filtered() {
+      if (this.filter === 'active') return this.tasks.filter((t) => t.status !== 'done')
+      if (this.filter === 'done') return this.tasks.filter((t) => t.status === 'done')
+      return this.tasks
+    },
+    doneCount() {
+      return this.$store.getters['todos/count']('done')
+    },
+    emptyHeading() {
+      if (this.filter === 'done') return 'Nothing completed yet'
+      if (this.filter === 'active') return 'All clear'
+      return 'Your day is wide open'
+    },
+    emptySub() {
+      if (this.filter === 'done') return 'Finished tasks will show up here.'
+      if (this.filter === 'active') return 'No active tasks — enjoy the calm.'
+      return 'Add your first task above to get started.'
+    },
+  },
+  methods: {
+    add() {
+      const title = this.draft.trim()
+      if (!title) return
+      this.$store.commit('todos/add', { title, status: 'todo' })
+      this.draft = ''
+    },
+    toggle(task) {
+      this.$store.commit('todos/toggle', task)
+    },
+    remove(id) {
+      this.$store.commit('todos/remove', id)
+    },
+    clearDone() {
+      this.$store.commit('todos/clearDone')
+    },
+    countFor(key) {
+      if (key === 'active') return this.tasks.filter((t) => t.status !== 'done').length
+      if (key === 'done') return this.doneCount
+      return this.tasks.length
+    },
+    statusLabel(s) {
+      return { todo: 'To do', progress: 'In progress', done: 'Completed' }[s]
+    },
+    avatarStyle(initials) {
+      let sum = 0
+      for (let i = 0; i < initials.length; i++) sum += initials.charCodeAt(i)
+      const [a, b] = PALETTE[sum % PALETTE.length]
+      return { backgroundImage: `linear-gradient(135deg, ${a}, ${b})` }
+    },
+  },
+}
 </script>
 
-<style lang="scss" scoped>
-.todo__item {
-  background-color: #e0e8e7;
+<style scoped>
+.today {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  max-width: 760px;
+  margin: 0 auto;
 }
-.todo__item--add {
-  background-color: #bccac1;
-  text-align: center;
+
+.quickadd {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 12px 12px 18px;
+  border-radius: var(--r-lg);
+}
+.quickadd__icon {
+  color: var(--accent);
+  flex: none;
+}
+.quickadd__input {
+  flex: 1;
+  min-width: 0;
+  height: 44px;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  font-size: 1rem;
+  font-family: inherit;
+}
+.quickadd__input:focus {
+  outline: none;
+}
+.quickadd__input::placeholder {
+  color: var(--text-muted);
+}
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.today__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.filters {
+  display: flex;
+  gap: 6px;
+}
+.filters__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 14px;
+  border-radius: 9999px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--dur) var(--ease);
+}
+.filters__pill:hover {
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+.filters__pill.is-active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+.filters__num {
+  font-size: 0.72rem;
+  background: var(--surface-2);
+  color: var(--text-secondary);
+  border-radius: 9999px;
+  padding: 1px 7px;
+}
+.filters__pill.is-active .filters__num {
+  background: rgba(255, 255, 255, 0.25);
+  color: #fff;
+}
+.today__clear {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 0;
+  background: none;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 6px 8px;
   border-radius: 8px;
-  padding: 4px 0;
-  i {
-    color: #6aa7b3;
-  }
+  transition: color var(--dur) var(--ease), background-color var(--dur) var(--ease);
 }
-.todo__item-relationship {
-  .todo__item-person {
-    line-height: 36px;
-    background-color: #f04c0f;
+.today__clear:hover {
+  color: var(--p-high);
+  background: rgba(239, 68, 68, 0.1);
+}
+
+.task-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  position: relative;
+}
+.row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  box-shadow: var(--shadow-xs);
+  transition: box-shadow var(--dur) var(--ease), border-color var(--dur) var(--ease),
+    transform var(--dur) var(--ease);
+}
+.row:hover {
+  box-shadow: var(--shadow-md);
+  border-color: var(--border-strong);
+  transform: translateY(-1px);
+}
+.row__check {
+  width: 24px;
+  height: 24px;
+  flex: none;
+  border-radius: 9999px;
+  border: 2px solid var(--border-strong);
+  background: var(--surface);
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all var(--dur) var(--ease);
+}
+.row__check.prio-high { border-color: var(--p-high); }
+.row__check.prio-medium { border-color: var(--p-medium); }
+.row__check.prio-low { border-color: var(--p-low); }
+.row__check:hover {
+  transform: scale(1.1);
+}
+.is-done .row__check {
+  background: var(--c-done);
+  border-color: var(--c-done);
+  animation: check-pop 0.42s var(--spring);
+}
+.row__body {
+  flex: 1;
+  min-width: 0;
+}
+.row__title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text);
+}
+.is-done .row__title {
+  text-decoration: line-through;
+  color: var(--text-muted);
+}
+.row__meta {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 5px;
+  flex-wrap: wrap;
+}
+.row__tag {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+.row__status {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+.row__status[data-s='progress'] { color: var(--c-progress); }
+.row__status[data-s='done'] { color: var(--c-done); }
+
+.row__avatars {
+  display: flex;
+  align-items: center;
+}
+.row__avatar {
+  width: 28px;
+  height: 28px;
+}
+.row__avatar + .row__avatar {
+  margin-left: -8px;
+}
+.row__del {
+  width: 32px;
+  height: 32px;
+  flex: none;
+  border-radius: 9px;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0;
+  transition: all var(--dur) var(--ease);
+}
+.row:hover .row__del {
+  opacity: 1;
+}
+.row__del:hover {
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--p-high);
+}
+
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 56px 20px;
+  text-align: center;
+  color: var(--text-muted);
+}
+.empty__icon {
+  color: var(--c-done);
+  opacity: 0.5;
+  margin-bottom: 4px;
+}
+.empty h3 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 1.15rem;
+  color: var(--text-secondary);
+}
+.empty p {
+  margin: 0;
+  font-size: 0.88rem;
+}
+
+@media (max-width: 560px) {
+  .quickadd .btn span,
+  .quickadd .btn {
+    white-space: nowrap;
   }
-  &:nth-child(2) {
-    background-color: darkgoldenrod;
+  .today__head {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }
 </style>

--- a/pages/todos.vue
+++ b/pages/todos.vue
@@ -1,38 +1,367 @@
 <template>
-  <ul class="flex justify-center flex-col my-48">
-    <li v-for="todo in todos" :key="todo.text" class="m-auto">
-      <input :checked="todo.done" @change="toggle(todo)" type="checkbox" />
-      <span :class="{ done: todo.done }">{{ todo.text }}</span>
-    </li>
-    <li class="m-auto">
-      <input @keyup.enter="addTodo" placeholder="What needs to be done?" />
-    </li>
-  </ul>
+  <div class="board anim-fade-in">
+    <div class="board__stats stagger">
+      <div v-for="s in stats" :key="s.key" class="stat surface-card">
+        <span class="stat__icon" :style="{ background: s.soft, color: s.color }">
+          <Icon :name="s.icon" :size="20" />
+        </span>
+        <div class="stat__body">
+          <span class="stat__value"><AnimatedNumber :value="s.value" /></span>
+          <span class="stat__label">{{ s.label }}</span>
+        </div>
+      </div>
+
+      <div class="stat stat--progress surface-card">
+        <div class="ring" :style="ringStyle">
+          <span class="ring__text"><AnimatedNumber :value="ringProgress" suffix="%" /></span>
+        </div>
+        <div class="stat__body">
+          <span class="stat__value">On track</span>
+          <span class="stat__label">Completion rate</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="board__tabs">
+      <button
+        v-for="(col, i) in columns"
+        :key="col.key"
+        class="board__tab"
+        :class="{ 'is-active': activeCol === i }"
+        @click="activeCol = i"
+      >
+        <span class="board__tab-dot" :style="{ background: col.color }"></span>
+        {{ col.title }}
+        <span class="board__tab-num">{{ tasksFor(col.key).length }}</span>
+      </button>
+    </div>
+
+    <div class="board__columns" :class="'show-' + activeCol">
+      <TaskColumn
+        v-for="col in columns"
+        :key="col.key"
+        :status-key="col.key"
+        :title="col.title"
+        :color="col.color"
+        :tasks="tasksFor(col.key)"
+        :is-over="overColumn === col.key"
+        @add="addTask"
+        @toggle="toggle"
+        @remove="remove"
+        @advance="advance"
+        @card-dragstart="onCardDragStart"
+        @card-dragend="onCardDragEnd"
+        @over="overColumn = $event"
+        @leave="onLeave"
+        @drop="onDrop"
+      />
+    </div>
+  </div>
 </template>
 
 <script>
-import { mapMutations } from 'vuex'
+import { STATUSES } from '~/store/todos'
+
+const NEXT = { todo: 'progress', progress: 'done' }
 
 export default {
+  name: 'BoardPage',
+  data() {
+    return {
+      draggedId: null,
+      overColumn: null,
+      activeCol: 0,
+      ringProgress: 0,
+      columns: [
+        { key: 'todo', title: 'To do', color: 'var(--c-todo)' },
+        { key: 'progress', title: 'In progress', color: 'var(--c-progress)' },
+        { key: 'done', title: 'Completed', color: 'var(--c-done)' },
+      ],
+    }
+  },
   computed: {
-    todos() {
-      return this.$store.state.todos.list
+    progress() {
+      return this.$store.getters['todos/progress']
+    },
+    ringStyle() {
+      const deg = (this.ringProgress / 100) * 360
+      return {
+        background: `conic-gradient(var(--accent) ${deg}deg, var(--surface-3) ${deg}deg)`,
+      }
+    },
+    stats() {
+      const g = this.$store.getters
+      return [
+        {
+          key: 'total',
+          label: 'Total tasks',
+          value: g['todos/total'],
+          icon: 'layers',
+          color: 'var(--c-todo)',
+          soft: 'var(--c-todo-soft)',
+        },
+        {
+          key: 'progress',
+          label: 'In progress',
+          value: g['todos/count']('progress'),
+          icon: 'clock',
+          color: 'var(--c-progress)',
+          soft: 'var(--c-progress-soft)',
+        },
+        {
+          key: 'done',
+          label: 'Completed',
+          value: g['todos/count']('done'),
+          icon: 'check',
+          color: 'var(--c-done)',
+          soft: 'var(--c-done-soft)',
+        },
+      ]
     },
   },
-  methods: {
-    addTodo(e) {
-      this.$store.commit('todos/add', e.target.value)
-      e.target.value = ''
+  watch: {
+    progress(val) {
+      this.ringProgress = val
     },
-    ...mapMutations({
-      toggle: 'todos/toggle',
-    }),
+  },
+  mounted() {
+    // let the ring sweep from 0 to its real value on first paint
+    this.$nextTick(() => {
+      window.requestAnimationFrame(() => {
+        this.ringProgress = this.progress
+      })
+    })
+  },
+  methods: {
+    tasksFor(status) {
+      return this.$store.getters['todos/byStatus'](status)
+    },
+    addTask(payload) {
+      this.$store.commit('todos/add', payload)
+    },
+    toggle(task) {
+      this.$store.commit('todos/toggle', task)
+    },
+    remove(id) {
+      this.$store.commit('todos/remove', id)
+    },
+    advance(task) {
+      const status = NEXT[task.status]
+      if (status) this.$store.commit('todos/update', { id: task.id, patch: { status } })
+    },
+    onCardDragStart(task) {
+      this.draggedId = task.id
+    },
+    onCardDragEnd() {
+      this.draggedId = null
+      this.overColumn = null
+    },
+    onLeave(key) {
+      if (this.overColumn === key) this.overColumn = null
+    },
+    onDrop(status) {
+      if (this.draggedId && STATUSES.includes(status)) {
+        this.$store.commit('todos/update', {
+          id: this.draggedId,
+          patch: { status },
+        })
+      }
+      this.draggedId = null
+      this.overColumn = null
+    },
   },
 }
 </script>
 
-<style lang="scss" scoped>
-.done {
-  text-decoration: line-through;
+<style scoped>
+.board {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+/* Fine dot-grid that fades in behind the board — a designer's surface,
+   not a flat wall. Masked so it never reaches the edges. */
+.board::before {
+  content: '';
+  position: absolute;
+  inset: -60px -40px;
+  z-index: 0;
+  pointer-events: none;
+  background-image: radial-gradient(var(--grid-dot) 1px, transparent 1.5px);
+  background-size: 26px 26px;
+  -webkit-mask-image: radial-gradient(
+    ellipse 70% 55% at 50% 38%,
+    #000 0%,
+    transparent 78%
+  );
+  mask-image: radial-gradient(
+    ellipse 70% 55% at 50% 38%,
+    #000 0%,
+    transparent 78%
+  );
+}
+.board > * {
+  position: relative;
+  z-index: 1;
+}
+
+.board__stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+.stat {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 16px 18px;
+  border-radius: var(--r-lg);
+}
+.stat__icon {
+  width: 46px;
+  height: 46px;
+  border-radius: 13px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+}
+.stat__body {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+.stat__value {
+  font-family: var(--font-display);
+  font-size: 1.6rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+.stat__label {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+.ring {
+  width: 46px;
+  height: 46px;
+  border-radius: 9999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  transition: background 0.6s var(--ease);
+}
+.ring__text {
+  width: 34px;
+  height: 34px;
+  border-radius: 9999px;
+  background: var(--surface);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.board__columns {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: start;
+}
+
+/* Mobile column switcher — hidden on desktop */
+.board__tabs {
+  display: none;
+  gap: 8px;
+  padding: 4px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-full);
+  box-shadow: inset 0 1px 0 var(--inset-hi);
+}
+.board__tab {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 9px 8px;
+  border: 0;
+  border-radius: var(--r-full);
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: inherit;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color var(--dur) var(--ease), color var(--dur) var(--ease),
+    box-shadow var(--dur) var(--ease);
+}
+.board__tab.is-active {
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: var(--shadow-sm);
+}
+.board__tab-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 9999px;
+}
+.board__tab-num {
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+
+@media (max-width: 1100px) {
+  .board__stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+@media (max-width: 860px) {
+  /* Phone: one focused column at a time, chosen via the tab switcher.
+     A real layout decision, not a squeeze. */
+  .board::before {
+    display: none;
+  }
+  .board__tabs {
+    display: flex;
+  }
+  .board .board__columns {
+    grid-template-columns: 1fr;
+  }
+  .board .board__columns > * {
+    display: none;
+  }
+  .board .board__columns.show-0 > *:nth-child(1),
+  .board .board__columns.show-1 > *:nth-child(2),
+  .board .board__columns.show-2 > *:nth-child(3) {
+    display: flex;
+    animation: fade-up 0.4s var(--ease) both;
+  }
+}
+@media (max-width: 520px) {
+  /* tidy 2x2 instead of a tall stack */
+  .board__stats {
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+  }
+  .stat {
+    padding: 14px;
+    gap: 11px;
+  }
+  .stat__icon,
+  .ring {
+    width: 40px;
+    height: 40px;
+  }
+  .stat__value {
+    font-size: 1.4rem;
+  }
 }
 </style>

--- a/plugins/persist.client.js
+++ b/plugins/persist.client.js
@@ -1,0 +1,28 @@
+const KEY = 'tasks-board-v1'
+
+export default ({ store }) => {
+  // Hydrate from localStorage (falls back to seed data on first visit)
+  try {
+    const saved = window.localStorage.getItem(KEY)
+    if (saved) {
+      const parsed = JSON.parse(saved)
+      if (Array.isArray(parsed)) store.commit('todos/hydrate', parsed)
+      else store.commit('todos/markHydrated')
+    } else {
+      store.commit('todos/markHydrated')
+    }
+  } catch (e) {
+    store.commit('todos/markHydrated')
+  }
+
+  // Persist on every board mutation
+  store.subscribe((mutation, state) => {
+    if (mutation.type.startsWith('todos/') && mutation.type !== 'todos/hydrate') {
+      try {
+        window.localStorage.setItem(KEY, JSON.stringify(state.todos.tasks))
+      } catch (e) {
+        /* storage full or unavailable — ignore */
+      }
+    }
+  })
+}

--- a/store/todos.js
+++ b/store/todos.js
@@ -1,18 +1,134 @@
+export const STATUSES = ['todo', 'progress', 'done']
+
+const uid = () =>
+  Date.now().toString(36) + Math.random().toString(36).slice(2, 7)
+
+const seed = () => [
+  {
+    id: uid(),
+    title: 'Design concept exploration',
+    description:
+      'Two different concepts for the software page. Keep the colors similar but feel free to introduce a fresh accent.',
+    status: 'todo',
+    priority: 'high',
+    tags: ['Design'],
+    assignees: ['TN', 'VE'],
+    createdAt: Date.now() - 86400000 * 2,
+  },
+  {
+    id: uid(),
+    title: 'Secured web platform',
+    description:
+      'Integrate and pull data from the other web apps we subscribe to via their APIs.',
+    status: 'todo',
+    priority: 'medium',
+    tags: ['Development'],
+    assignees: ['JE'],
+    createdAt: Date.now() - 86400000,
+  },
+  {
+    id: uid(),
+    title: 'Dynamic deep links',
+    description: 'Make links work seamlessly across the iOS and Android apps.',
+    status: 'progress',
+    priority: 'medium',
+    tags: ['Development', 'Mobile'],
+    assignees: ['SW', 'GJ'],
+    createdAt: Date.now() - 86400000 * 3,
+  },
+  {
+    id: uid(),
+    title: 'Logo redesign',
+    description:
+      'Keep the exact shape but make the gradient one solid color instead of light-to-deep red.',
+    status: 'progress',
+    priority: 'low',
+    tags: ['Branding'],
+    assignees: ['AV', 'TN'],
+    createdAt: Date.now() - 86400000 * 4,
+  },
+  {
+    id: uid(),
+    title: 'Onboarding copywriting',
+    description: 'Final pass on the welcome flow microcopy.',
+    status: 'done',
+    priority: 'low',
+    tags: ['Content'],
+    assignees: ['VE'],
+    createdAt: Date.now() - 86400000 * 6,
+  },
+]
+
 export const state = () => ({
-  list: [],
+  tasks: seed(),
+  hydrated: false,
 })
 
+export const getters = {
+  byStatus: (state) => (status) =>
+    state.tasks.filter((t) => t.status === status),
+  count: (state) => (status) =>
+    state.tasks.filter((t) => t.status === status).length,
+  total: (state) => state.tasks.length,
+  progress: (state) => {
+    if (!state.tasks.length) return 0
+    const done = state.tasks.filter((t) => t.status === 'done').length
+    return Math.round((done / state.tasks.length) * 100)
+  },
+}
+
 export const mutations = {
-  add(state, text) {
-    state.list.push({
-      text,
-      done: false,
+  hydrate(state, tasks) {
+    if (Array.isArray(tasks)) state.tasks = tasks
+    state.hydrated = true
+  },
+  markHydrated(state) {
+    state.hydrated = true
+  },
+  add(state, payload) {
+    const task =
+      typeof payload === 'string'
+        ? { title: payload }
+        : { ...payload }
+    state.tasks.unshift({
+      id: uid(),
+      title: (task.title || 'Untitled task').trim(),
+      description: task.description || '',
+      status: STATUSES.includes(task.status) ? task.status : 'todo',
+      priority: task.priority || 'medium',
+      tags: task.tags || [],
+      assignees: task.assignees || [],
+      createdAt: Date.now(),
     })
   },
-  remove(state, { todo }) {
-    state.list.splice(state.list.indexOf(todo), 1)
+  update(state, { id, patch }) {
+    const task = state.tasks.find((t) => t.id === id)
+    if (task) Object.assign(task, patch)
+  },
+  remove(state, id) {
+    const target = typeof id === 'object' && id ? id.id : id
+    const i = state.tasks.findIndex((t) => t.id === target)
+    if (i !== -1) state.tasks.splice(i, 1)
+  },
+  move(state, { id, status, before }) {
+    const i = state.tasks.findIndex((t) => t.id === id)
+    if (i === -1) return
+    const [task] = state.tasks.splice(i, 1)
+    if (STATUSES.includes(status)) task.status = status
+    if (before == null) {
+      state.tasks.push(task)
+    } else {
+      const idx = state.tasks.findIndex((t) => t.id === before)
+      if (idx === -1) state.tasks.push(task)
+      else state.tasks.splice(idx, 0, task)
+    }
   },
   toggle(state, todo) {
-    todo.done = !todo.done
+    const id = todo && todo.id ? todo.id : todo
+    const task = state.tasks.find((t) => t.id === id)
+    if (task) task.status = task.status === 'done' ? 'todo' : 'done'
+  },
+  clearDone(state) {
+    state.tasks = state.tasks.filter((t) => t.status !== 'done')
   },
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,13 @@
 module.exports = {
   purge: [],
-  darkMode: false, // or 'media' or 'class'
+  darkMode: 'class',
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['Satoshi', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        display: ['Clash Display', 'Satoshi', 'sans-serif'],
+      },
+    },
   },
   variants: {
     extend: {},


### PR DESCRIPTION
## Overview
Elevates the app from a rough learning demo into a production-grade **Modern Minimal** product with light + dark themes — and makes it actually functional end to end (persisted kanban, drag-and-drop).

## Design system
- CSS-variable design tokens (light/dark) in `assets/styles/theme.scss`
- Typography: **Clash Display** (headings) + **Satoshi** (body) via Fontshare — no Inter/Roboto
- Crafted surfaces: near-invisible **film grain**, a **dot-grid** that fades in behind the board, lit-from-above highlights on cards/columns
- Hand-crafted micro-interactions: drawn-in checkmarks with a completion pop, count-up stats, progress that sweeps from zero, button sheen sweep, one-time card intro halo, springy nav indicator + advance arrow, rotating theme toggle
- `prefers-reduced-motion` respected; no-flash theme via inline head script

## Functionality
- Vuex store reworked into a real kanban model (`status` / `priority` / `tags` / `assignees`)
- **localStorage persistence** (`plugins/persist.client.js`) — hydrate on load, save on every mutation
- **Native drag-and-drop** between columns + tap-to-advance for touch
- Inline quick-add, toggle-done, delete

## Screens & shell
- New app shell: `TheSidebar`, `TheTopbar`, `ThemeToggle`, `Icon` (Lucide-style inline SVG)
- Kanban board with stat cards + conic progress ring (`pages/todos.vue`)
- "Today" list view, add-task form with **live preview**, redesigned about page
- **Mobile**: a real layout decision — segmented column switcher (one focused list at a time) + 2×2 stat grid, not a desktop squeeze

## Verification
- `nuxt build` compiles cleanly
- All four routes SSR with **zero console errors** (light + dark)
- Fonts confirmed loaded; add / toggle / persistence and mobile column switching tested live

## Notes
- Requires Node-legacy OpenSSL to build on Node 22: `NODE_OPTIONS=--openssl-legacy-provider` (Nuxt 2 / webpack 4)
- `.gitignore` updated to ignore the local `.gstack/` tooling dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)